### PR TITLE
Pass Serverless options through to child functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ class LambdaOffline {
     const { servicePath } = this.serverless.config;
     const serviceRuntime = this.service.provider.runtime;
 
-    const funOptions = Object.keys(this.service.functions).reduce((acc, key) => {
+    const funOptionsCache = Object.keys(this.service.functions).reduce((acc, key) => {
       const fun = this.service.getFunction(key);
       acc[key] = functionHelper.getFunctionOptions(fun, key, servicePath, serviceRuntime);
       return acc;
@@ -42,13 +42,13 @@ class LambdaOffline {
           const invocationType = req.headers['x-amz-invocation-type'];
           const { functionName } = req.params;
 
-          const options = funOptions[functionName];
+          const funOptions = funOptionsCache[functionName];
 
-          if (!options) {
+          if (!funOptions) {
             return reply().code(404);
           }
 
-          const handler = functionHelper.createHandler(options, {});
+          const handler = functionHelper.createHandler(funOptions, this.options);
 
           if (!handler) {
             return reply().code(404);


### PR DESCRIPTION
This fixes the error:

    ServerlessError: Trying to populate non string value into a string for variable ${opt:stage}. Please make sure the value of the property is a string.
        at Variables.populateVariable (/usr/lib/node_modules/serverless/lib/classes/Variables.js:421:13)

Which happens because my `serverless.yml` uses the `${opt:stage}` variable.  This is normally set with `--stage test` or similar, however this was being lost when the target Lambda function was being called.

This patch passes the options through to the child Lambda function, so any options passed to the parent process will also be passed along to the child ones.