### PR TITLE
Compose service path when location option is provided via offline CLI

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const Hapi = require('hapi');
 const functionHelper = require('serverless-offline/src/functionHelper');
 
@@ -40,7 +41,7 @@ class LambdaOffline {
     this.server = new Hapi.Server();
     this.server.connection({ port: this.config.port, host: this.config.host });
 
-    const { servicePath } = this.serverless.config;
+    const servicePath = path.join(this.serverless.config.servicePath, this.options.location);
     const serviceRuntime = this.service.provider.runtime;
 
     const funOptionsCache = Object.keys(this.service.functions).reduce((acc, key) => {


### PR DESCRIPTION
Hi!

First of all, thanks for the plugin, it is helping me a lot!

I'm executing serverless offline with this plugin and found out that this wasn't working as expected:

`sls offline start --location '../'`

This small contribution contemplates that option using `path.join` as it is used in `serverless-offline/src/index.js` > `_createRoutes` method
There is no error in using `path.join` when `--location` is not provided since it defaults to current dir `./`.

Thanks